### PR TITLE
bugfix: sort plan spots

### DIFF
--- a/app/controllers/plan_days_controller.rb
+++ b/app/controllers/plan_days_controller.rb
@@ -10,13 +10,18 @@ class PlanDaysController < ApplicationController
 
   def cand_sort
     @plan_day = PlanDay.find( params[:id] )
-    @spots = Spot.find( params[:plan_spot] )
-    @plan_day.spots = @spots
 
-    params['plan_spot'].each_with_index do |spot_id, idx|
-      ps = PlanSpot.where( plan_day_id: @plan_day.id, spot_id: spot_id ).first
-      ps.position = idx + 1
-      ps.save
+    if params[:plan_spot]
+      @spots = Spot.find( params[:plan_spot] )
+      @plan_day.spots = @spots
+    
+      params['plan_spot'].each_with_index do |spot_id, idx|
+        ps = PlanSpot.where( plan_day_id: @plan_day.id, spot_id: spot_id ).first
+        ps.position = idx + 1
+        ps.save
+      end
+    else
+      @plan_day.spots = []
     end
 
     render :nothing => true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,9 +4,9 @@ Localis::Application.routes.draw do
 
   resources :generals
 
-  get "plan_days/show/:id" => "plan_days#show", :as => :plan_day
-  get "plan_days/edit/:id" => "plan_days#edit", :as => :edit_plan_day
-  post "cand_sort"     => "plan_days#cand_sort"
+  get  "plan_days/show/:id"      => "plan_days#show",      :as => :plan_day
+  get  "plan_days/edit/:id"      => "plan_days#edit",      :as => :edit_plan_day
+  post "plan_days/:id/cand_sort" => "plan_days#cand_sort"
 
   resources :plans
 


### PR DESCRIPTION
- sort のルーティングがおかしかったので直した
- plan spots が空になったときにエラーになってたのを直した
